### PR TITLE
feat: embed SAM QC plots in MultiQC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Nextflow-based pipeline for single-cell RNA sequencing data preprocessing, spe
 - **Ambient RNA removal** for cleaner expression profiles
 - **Doublet detection** to filter multiplets
 - **Comprehensive QC metrics** with MultiQC reporting
+- **Embedded QC plots** included in MultiQC report
 - **Automated preprocessing** with minimal manual intervention
 
 ## Future Development

--- a/main.nf
+++ b/main.nf
@@ -39,6 +39,7 @@ workflow {
         .mix(SAM_QC.out.qc_cells_metrics)
         .mix(SAM_QC.out.qc_counts_metrics)
         .mix(SAM_QC.out.qc_genes_metrics)
+        .mix(SAM_QC.out.qc_plots)
         .collect()
 
     // 4.2 Create a channel pointing to the configuration file

--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -28,6 +28,11 @@ custom_content:
       sortRows: false
       id: 'genes_metrics_table'
 
+  sam_qc_plots:
+    file_format: png
+    plot_type: image
+    section_name: "SAM QC Plots"
+
 
 sp:
   cells_metrics:
@@ -36,6 +41,8 @@ sp:
     fn: "*_counts_metrics.tsv"
   genes_metrics:
     fn: "*_genes_metrics.tsv"
+  sam_qc_plots:
+    fn: "*.png"
 
 module_order:
   - star


### PR DESCRIPTION
## Summary
- pass SAM_QC image outputs to MultiQC for inclusion in final report
- render SAM QC plots via custom MultiQC configuration
- document embedded QC plots in README

## Testing
- `multiqc --version`
- `nextflow -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a367e2cb248324a701c5534fe3aa92