### PR TITLE
refactor: run scrublet before SoupX

### DIFF
--- a/bin/run_sam_qc.py
+++ b/bin/run_sam_qc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import scanpy as sc
-import scrublet as scr
 import pandas as pd
 import numpy as np
 import argparse
@@ -12,154 +11,27 @@ from samalg import SAM
 def run_qc2(
     sample_id,
     input_h5ad,
-    min_genes,
-    min_cells,
-    max_genes,
-    max_counts,
-    max_mito,
-    mito_prefixes,
-    mito_gene_list,
+    whitelist,
     n_hvg,
     n_neighbors,
     n_pcs,
     marker_genes_file=None,
 ):
-    """
-    Run single-cell data QC.
-    adata - after removing ambient RNA, filter lower limits
-    adata_QC1 - mitochondria filtration
-    adata_QC2 - doublet removal
-    """
-    # 1. Load data
+    """Run single-cell data QC after SoupX correction using precomputed whitelist."""
     adata = sc.read_h5ad(input_h5ad)
     adata.var_names_make_unique()
-    sc.pp.normalize_total(adata, target_sum=1e6) #log2 CPM, but input has been processed by SoupX
+    sc.pp.normalize_total(adata, target_sum=1e6)
     sc.pp.log1p(adata)
 
+    keep_cells = pd.read_csv(whitelist, header=None)[0].tolist()
+    adata = adata[adata.obs_names.isin(keep_cells), :]
 
-    # 2. --- Initial filtering and QC calculations ---
-    # a. Basic filtering on lower limit
-    sc.pp.filter_cells(adata, min_genes=min_genes)
-    sc.pp.filter_genes(adata, min_cells=min_cells)
-    print("---mito list---")
-    print(max_mito)
-    print(mito_gene_list)
-    print("---mito list---")
-    # b. Calculate mitochondrial gene percentage
-    if mito_gene_list:
-        with open(mito_gene_list) as f:
-            mito_genes = {line.strip() for line in f if line.strip()}
-        adata.var['mito'] = adata.var_names.isin(mito_genes)
-    else:
-        adata.var['mito'] = adata.var_names.str.startswith(tuple(mito_prefixes))
-    sc.pp.calculate_qc_metrics(
-        adata, qc_vars=['mito'], percent_top=None, log1p=False, inplace=True
-    )
+    sc.pp.highly_variable_genes(adata, n_top_genes=n_hvg)
+    sc.pp.pca(adata, n_comps=n_pcs)
+    sc.pp.neighbors(adata, n_neighbors=n_neighbors, n_pcs=n_pcs)
 
-    adata_QC1 = adata[adata.obs.pct_counts_mito < max_mito * 100, :] # Scanpy calculates this as a percentage
-
-
-    # c. Filter doublets
-    # @Prateek I didn't filter the upper limit here as I think they would be duplicated with function of SCR
-    # adata = adata[adata.obs.n_genes_by_counts < max_genes, :]
-    # adata = adata[adata.obs.total_counts < max_counts, :]
-    raw_matrix = adata_QC1.X.todense()
-    scrub = scr.Scrublet(raw_matrix)
-    doublet_score, predicted_doublets = scrub.scrub_doublets()
-    real_cells = np.logical_not(predicted_doublets)
-    adata_QC1.obs['predicted_doublet'] = predicted_doublets
-
-    # # Backup: Cell number dependent doublet expectation (https://kb.10xgenomics.com/hc/en-us/articles/360054599512-What-is-the-cell-multiplet-rate-when-using-the-3-CellPlex-Kit-for-Cell-Multiplexing)
-    # rate = adata_QC1.n_obs / 1000 * 0.008
-    # scrub = scr.Scrublet(adata_QC1.X, expected_doublet_rate=rate, random_state=0)
-    # adata_QC1.obs['doublet_score'], predicted_doublets = scrub.scrub_doublets()
-    # scrub.plot_histogram()
-    # plt.show()
-    # auto_threshold = scrub.threshold_
-    # final_threshold = auto_threshold
-    # adata_QC1.obs['predicted_doublet'] = adata_QC1.obs['doublet_score'] > final_threshold
-    #
-    adata_QC2 = adata_QC1[real_cells,:]
-
-    # e. Identify highly variable genes and compute PCA/neighbor graph
-    sc.pp.highly_variable_genes(adata_QC2, n_top_genes=n_hvg)
-    sc.pp.pca(adata_QC2, n_comps=n_pcs)
-    sc.pp.neighbors(adata_QC2, n_neighbors=n_neighbors, n_pcs=n_pcs)
-
-    # d. Create QC plots
-    # Fig 0: Mitochodria Removal
-    fig0, axes = plt.subplots(1, 2, figsize=(15, 5))
-    sc.pl.violin(adata, 'pct_counts_mito', jitter=0.4, ax=axes[0], show=False)
-    sc.pl.violin(adata_QC1, 'pct_counts_mito', jitter=0.4, ax=axes[1], show=False)
-    fig0.suptitle(f'{sample_id} - Mito Filtering - QC1')
-    fig0.tight_layout()
-    fig0.savefig(f'1.{sample_id}_violin_mito_filtering_QC1.png')
-    plt.close(fig0)
-
-    # Fig 1: Doublet cells shown on scatter plots
-    adata_QC1.obs['predicted_doublet'] = adata_QC1.obs['predicted_doublet'].astype('category')
-    custom_palette = ['#DDDDDD', 'red']
-    fig1, ax = plt.subplots()
-    sc.pl.scatter(
-        adata_QC1,  # as marks saved within QC1
-        x='total_counts',
-        y='n_genes_by_counts',
-        color='predicted_doublet',
-        palette=custom_palette,
-        ax=ax,
-        show=False,
-        title=f'{sample_id} - Predicted Doublets Highlighted - QC2'
-    )
-    fig1.savefig(
-    f'2.{sample_id}_scatter_doublet_highlight_QC2.png',
-    dpi=300,
-    bbox_inches='tight')
-    plt.close(fig1)
-
-    # Fig 2: Global violin before and after doublet removal
-    fig2, axes = plt.subplots(2, 2, figsize=(18, 10))
-    fig2.suptitle(f'{sample_id} - QC Metrics: Before vs. After Doublet Removal', fontsize=16)
-
-    axes[0, 0].set_title('Genes per Cell (Before)')
-    sc.pl.violin(adata_QC1, 'n_genes_by_counts', jitter=0.4, ax=axes[0, 0], show=False)
-    axes[0, 1].set_title('Counts per Cell (Before)')
-    sc.pl.violin(adata_QC1, 'total_counts', jitter=0.4, ax=axes[0, 1], show=False)
-
-    axes[1, 0].set_title('Genes per Cell (After)')
-    sc.pl.violin(adata_QC2, 'n_genes_by_counts', jitter=0.4, ax=axes[1, 0], show=False)
-    axes[1, 1].set_title('Counts per Cell (After)')
-    sc.pl.violin(adata_QC2, 'total_counts', jitter=0.4, ax=axes[1, 1], show=False)
-
-    fig2.tight_layout(rect=[0, 0.03, 1, 0.95])
-    fig2.savefig(f'3.{sample_id}_violin_comparison_QC2.png')
-    plt.close(fig2)
-
-
-    # e. Save stats for multiqc
-    # --- Save pre-filtering statistics for MultiQC use ---
-    number_cells = adata.n_obs
-    median_genes = np.median(adata.obs['n_genes_by_counts'])
-    median_counts = np.median(adata.obs['total_counts'])
-
-    number_cells_QC1 = adata_QC1.n_obs
-    median_genes_QC1 = np.median(adata_QC1.obs['n_genes_by_counts'])
-    median_counts_QC1 = np.median(adata_QC1.obs['total_counts'])
-
-    number_cells_QC2 = adata_QC2.n_obs
-    median_genes_QC2  = np.median(adata_QC2.obs['n_genes_by_counts'])
-    median_counts_QC2 = np.median(adata_QC2.obs['total_counts'])
-
-
-    # 3. CLUSTERING using SAM algorithm
-    # ----------------
-    # store raw (pre‐normalized) counts in .raw for safe‐keeping
-    adata_QC2.raw = adata_QC2.copy()
-    # The SAM library no longer accepts ``n_genes`` during initialization.
-    # Instead, instantiate ``SAM`` with the AnnData object and pass the
-    # desired number of genes and principal components to ``run`` via the
-    # ``n_genes`` and ``npcs`` arguments. Using the old ``d`` parameter
-    # caused a ``TypeError`` because it is not a valid keyword argument.
-    sam = SAM(adata_QC2)
+    adata.raw = adata.copy()
+    sam = SAM(adata)
     sam.run(
         projection='umap',
         preprocessing='StandardScaler',
@@ -167,19 +39,17 @@ def run_qc2(
         npcs=n_pcs,
         n_genes=n_hvg,
     )
-    sam.leiden_clustering(res=0.5) # As a QC pipeline, here the resolution is relatively low
+    sam.leiden_clustering(res=0.5)
 
-    # Fig 3: UMAP for Leiden clusters generated by SAM
     sc.pl.umap(
         sam.adata,
         color='leiden_clusters',
         show=False,
         title=f'{sample_id} - Leiden Clustering (UMAP) - QC2'
     )
-    plt.savefig(f'4.{sample_id}_umap_leiden_QC2.png',dpi=300, bbox_inches='tight')
+    plt.savefig(f'4.{sample_id}_umap_leiden_QC2.png', dpi=300, bbox_inches='tight')
     plt.close()
 
-    # Identify marker genes and plot heatmap
     sc.tl.rank_genes_groups(sam.adata, groupby='leiden_clusters', method='wilcoxon')
     rank_df = sc.get.rank_genes_groups_df(sam.adata, None)
     top_markers = rank_df.groupby('group').head(2)['names'].tolist()
@@ -205,9 +75,6 @@ def run_qc2(
         g.savefig(f'5.{sample_id}_marker_genes_heatmap.png')
         plt.close(g.fig)
 
-    # 4. EXPORT RAW COUNTS MATRIX
-    # ----------------------------
-    # pull it out as a dense DataFrame
     raw_mat = pd.DataFrame(
         sam.adata.raw.X.todense(),
         index=sam.adata.obs_names,
@@ -215,80 +82,23 @@ def run_qc2(
     )
     raw_mat.to_csv(f'{sample_id}_raw_counts.csv')
     sam.adata.obs['leiden_clusters'].to_csv(f'{sample_id}_leiden_clusters.csv', header=True)
-
-    # --- Generate a simple tab-delimited file for MultiQC ---
-    # with open(f'{sample_id}_qc_metrics.tsv', 'w') as f:
-    #     f.write("metric\tvalue\n")
-    #     f.write(f"cells_initial\t{number_cells}\n")
-    #     f.write(f"median_genes_initial\t{int(median_genes)}\n")
-    #     f.write(f"median_counts_initial\t{int(median_counts)}\n")
-    #     f.write(f"cells_after_MT_Removal\t{number_cells_QC1}\n")
-    #     f.write(f"median_genes_MT_Removal\t{int(median_genes_QC1)}\n")
-    #     f.write(f"median_counts_MT_Removal\t{int(median_counts_QC1)}\n")
-    #     f.write(f"cells_after_Doublet_Removal\t{number_cells_QC2}\n")
-    #     f.write(f"median_genes_Doublet_Removal\t{int(median_genes_QC2)}\n")
-    #     f.write(f"median_counts_Doublet_Removal\t{int(median_counts_QC2)}\n")
-
-    with open(f"{sample_id}_cells.tsv", "w") as f:
-        f.write("# plot_type: 'table'\n")
-        f.write("# section_name: 'Cells QC Metrics'\n")
-        f.write("# description: 'Cell counts at different filtering steps'\n")
-        f.write("# pconfig:\n")
-        f.write("#     sortRows: false\n")
-        f.write("Sample\tcells_initial\tcells_after_MT_Removal\tcells_after_Doublet_Removal\n")
-        f.write(f"{sample_id}\t{number_cells}\t{number_cells_QC1}\t{number_cells_QC2}\n")
-
-    with open(f"{sample_id}_counts.tsv", "w") as f:
-        f.write("# plot_type: 'table'\n")
-        f.write("# section_name: 'Counts QC Metrics'\n")
-        f.write("# description: 'Median UMI counts at different filtering steps'\n")
-        f.write("# pconfig:\n")
-        f.write("#     sortRows: false\n")
-        f.write("Sample\tmedian_counts_initial\tmedian_counts_MT_Removal\tmedian_counts_Doublet_Removal\n")
-        f.write(f"{sample_id}\t{int(median_counts)}\t{int(median_counts_QC1)}\t{int(median_counts_QC2)}\n")
-
-    with open(f"{sample_id}_genes.tsv", "w") as f:
-        f.write("# plot_type: 'table'\n")
-        f.write("# section_name: 'Genes QC Metrics'\n")
-        f.write("# description: 'Median genes at different filtering steps'\n")
-        f.write("# pconfig:\n")
-        f.write("#     sortRows: false\n")
-        f.write("Sample\tmedian_genes_initial\tmedian_genes_MT_Removal\tmedian_genes_Doublet_Removal\n")
-        f.write(f"{sample_id}\t{int(median_genes)}\t{int(median_genes_QC1)}\t{int(median_genes_QC2)}\n")
-
-    # Save processed AnnData object
     sam.adata.write_h5ad(f'{sample_id}_filtered_QC2.h5ad')
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Run SAM QC on STARsolo output")
+    parser = argparse.ArgumentParser(description="Run SAM QC on SoupX output")
     parser.add_argument('--sample_id', required=True, help="Sample identifier")
-    parser.add_argument('--input_h5ad', required=True, help="Sample h5ad")
-
-    #parser.add_argument('--matrix_dir', required=True, help="Path to STARsolo matrix directory")
-    parser.add_argument('--min_genes', type=int, default=600, help="Min genes per cell")
-    parser.add_argument('--min_cells', type=int, default=3, help="Min cells per gene")
-    parser.add_argument('--max_genes', type=int, default=6000, help="Max genes per cell")
-    parser.add_argument('--max_counts', type=int, default=20000, help="Max UMI counts per cell")
-    parser.add_argument('--max_mito', type=float, default=0.2, help="Max mitochondrial percentage (as a fraction, e.g., 0.2 for 20%)")
-    parser.add_argument('--mito_prefixes', nargs='+', default=['mt-'], help="Prefix(es) for mitochondrial genes")
-    parser.add_argument('--mito_gene_list', type=str, default=None, help="Path to text file listing mitochondrial genes (one per line)")
+    parser.add_argument('--input_h5ad', required=True, help="SoupX corrected h5ad")
+    parser.add_argument('--whitelist', required=True, help="Path to whitelist of non-doublet cells")
     parser.add_argument('--n_hvg', type=int, default=3000, help="Number of highly variable genes")
     parser.add_argument('--n_neighbors', type=int, default=15, help="Number of nearest neighbors in PCA space")
     parser.add_argument('--n_pcs', type=int, default=50, help="Number of principal components")
     parser.add_argument('--marker_genes', type=str, default=None, help="Optional path to marker genes list (one gene per line)")
-
     args = parser.parse_args()
 
     run_qc2(
         args.sample_id,
         args.input_h5ad,
-        args.min_genes,
-        args.min_cells,
-        args.max_genes,
-        args.max_counts,
-        args.max_mito,
-        args.mito_prefixes,
-        args.mito_gene_list,
+        args.whitelist,
         args.n_hvg,
         args.n_neighbors,
         args.n_pcs,

--- a/bin/run_scrublet.py
+++ b/bin/run_scrublet.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+import scanpy as sc
+import scrublet as scr
+import pandas as pd
+import numpy as np
+import argparse
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+def run_scrublet(sample_id, matrix_dir, min_genes, min_cells, max_mito, mito_prefixes, mito_gene_list=None):
+    adata = sc.read_10x_mtx(matrix_dir, var_names='gene_symbols')
+    adata.var_names_make_unique()
+
+    sc.pp.filter_cells(adata, min_genes=min_genes)
+    sc.pp.filter_genes(adata, min_cells=min_cells)
+
+    if mito_gene_list:
+        with open(mito_gene_list) as f:
+            mito_genes = {line.strip() for line in f if line.strip()}
+        adata.var['mito'] = adata.var_names.isin(mito_genes)
+    else:
+        adata.var['mito'] = adata.var_names.str.startswith(tuple(mito_prefixes))
+    sc.pp.calculate_qc_metrics(adata, qc_vars=['mito'], percent_top=None, log1p=False, inplace=True)
+
+    adata_QC1 = adata[adata.obs.pct_counts_mito < max_mito * 100, :]
+
+    raw_matrix = adata_QC1.X.todense()
+    scrub = scr.Scrublet(raw_matrix)
+    doublet_score, predicted_doublets = scrub.scrub_doublets()
+    adata_QC1.obs['predicted_doublet'] = predicted_doublets
+    adata_QC2 = adata_QC1[~predicted_doublets, :]
+
+    # Fig 0: Mitochondria removal
+    fig0, axes = plt.subplots(1, 2, figsize=(15, 5))
+    sc.pl.violin(adata, 'pct_counts_mito', jitter=0.4, ax=axes[0], show=False)
+    sc.pl.violin(adata_QC1, 'pct_counts_mito', jitter=0.4, ax=axes[1], show=False)
+    fig0.suptitle(f'{sample_id} - Mito Filtering - QC1')
+    fig0.tight_layout()
+    fig0.savefig(f'1.{sample_id}_violin_mito_filtering_QC1.png')
+    plt.close(fig0)
+
+    # Fig 1: Doublet scatter
+    adata_QC1.obs['predicted_doublet'] = adata_QC1.obs['predicted_doublet'].astype('category')
+    custom_palette = ['#DDDDDD', 'red']
+    fig1, ax = plt.subplots()
+    sc.pl.scatter(
+        adata_QC1,
+        x='total_counts',
+        y='n_genes_by_counts',
+        color='predicted_doublet',
+        palette=custom_palette,
+        ax=ax,
+        show=False,
+        title=f'{sample_id} - Predicted Doublets Highlighted - QC2'
+    )
+    fig1.savefig(
+        f'2.{sample_id}_scatter_doublet_highlight_QC2.png',
+        dpi=300,
+        bbox_inches='tight')
+    plt.close(fig1)
+
+    # Fig 2: Global violin before and after doublet removal
+    fig2, axes = plt.subplots(2, 2, figsize=(18, 10))
+    fig2.suptitle(f'{sample_id} - QC Metrics: Before vs. After Doublet Removal', fontsize=16)
+
+    axes[0, 0].set_title('Genes per Cell (Before)')
+    sc.pl.violin(adata_QC1, 'n_genes_by_counts', jitter=0.4, ax=axes[0, 0], show=False)
+    axes[0, 1].set_title('Counts per Cell (Before)')
+    sc.pl.violin(adata_QC1, 'total_counts', jitter=0.4, ax=axes[0, 1], show=False)
+
+    axes[1, 0].set_title('Genes per Cell (After)')
+    sc.pl.violin(adata_QC2, 'n_genes_by_counts', jitter=0.4, ax=axes[1, 0], show=False)
+    axes[1, 1].set_title('Counts per Cell (After)')
+    sc.pl.violin(adata_QC2, 'total_counts', jitter=0.4, ax=axes[1, 1], show=False)
+
+    fig2.tight_layout(rect=[0, 0.03, 1, 0.95])
+    fig2.savefig(f'3.{sample_id}_violin_comparison_QC2.png')
+    plt.close(fig2)
+
+    # Save whitelist
+    adata_QC2.obs_names.to_series().to_csv(f'{sample_id}_whitelist.txt', index=False, header=False)
+
+    # Save metrics for MultiQC
+    number_cells = adata.n_obs
+    median_genes = int(np.median(adata.obs['n_genes_by_counts']))
+    median_counts = int(np.median(adata.obs['total_counts']))
+
+    number_cells_QC1 = adata_QC1.n_obs
+    median_genes_QC1 = int(np.median(adata_QC1.obs['n_genes_by_counts']))
+    median_counts_QC1 = int(np.median(adata_QC1.obs['total_counts']))
+
+    number_cells_QC2 = adata_QC2.n_obs
+    median_genes_QC2 = int(np.median(adata_QC2.obs['n_genes_by_counts']))
+    median_counts_QC2 = int(np.median(adata_QC2.obs['total_counts']))
+
+    with open(f"{sample_id}_cells.tsv", "w") as f:
+        f.write("# plot_type: 'table'\n")
+        f.write("# section_name: 'Cells QC Metrics'\n")
+        f.write("# description: 'Cell counts at different filtering steps'\n")
+        f.write("# pconfig:\n")
+        f.write("#     sortRows: false\n")
+        f.write("Sample\tcells_initial\tcells_after_MT_Removal\tcells_after_Doublet_Removal\n")
+        f.write(f"{sample_id}\t{number_cells}\t{number_cells_QC1}\t{number_cells_QC2}\n")
+
+    with open(f"{sample_id}_counts.tsv", "w") as f:
+        f.write("# plot_type: 'table'\n")
+        f.write("# section_name: 'Counts QC Metrics'\n")
+        f.write("# description: 'Median UMI counts at different filtering steps'\n")
+        f.write("# pconfig:\n")
+        f.write("#     sortRows: false\n")
+        f.write("Sample\tmedian_counts_initial\tmedian_counts_MT_Removal\tmedian_counts_Doublet_Removal\n")
+        f.write(f"{sample_id}\t{median_counts}\t{median_counts_QC1}\t{median_counts_QC2}\n")
+
+    with open(f"{sample_id}_genes.tsv", "w") as f:
+        f.write("# plot_type: 'table'\n")
+        f.write("# section_name: 'Genes QC Metrics'\n")
+        f.write("# description: 'Median genes at different filtering steps'\n")
+        f.write("# pconfig:\n")
+        f.write("#     sortRows: false\n")
+        f.write("Sample\tmedian_genes_initial\tmedian_genes_MT_Removal\tmedian_genes_Doublet_Removal\n")
+        f.write(f"{sample_id}\t{median_genes}\t{median_genes_QC1}\t{median_genes_QC2}\n")
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Run Scrublet doublet detection")
+    parser.add_argument('--sample_id', required=True, help="Sample identifier")
+    parser.add_argument('--matrix_dir', required=True, help="Path to raw count matrix directory")
+    parser.add_argument('--min_genes', type=int, default=600, help="Min genes per cell")
+    parser.add_argument('--min_cells', type=int, default=3, help="Min cells per gene")
+    parser.add_argument('--max_mito', type=float, default=0.2, help="Max mitochondrial percentage (fraction)")
+    parser.add_argument('--mito_prefixes', nargs='+', default=['mt-'], help="Prefix(es) for mitochondrial genes")
+    parser.add_argument('--mito_gene_list', type=str, default=None, help="Path to text file listing mitochondrial genes (one per line)")
+    args = parser.parse_args()
+
+    run_scrublet(
+        args.sample_id,
+        args.matrix_dir,
+        args.min_genes,
+        args.min_cells,
+        args.max_mito,
+        args.mito_prefixes,
+        args.mito_gene_list,
+    )

--- a/modules/local/sam_qc.nf
+++ b/modules/local/sam_qc.nf
@@ -5,31 +5,21 @@ process SAM_QC {
     publishDir "$params.outdir/sam_qc/${meta.id}", mode: 'copy'
 
     input:
-    tuple val(meta), path(corrected_h5ad)
+    tuple val(meta), path(corrected_h5ad), path(whitelist)
 
     output:
     tuple val(meta), path("*.png"), emit: qc_plots
     tuple val(meta), path("*.h5ad"), emit: filtered_adata
-    path "*_cells.tsv", emit: qc_cells_metrics
-    path "*_counts.tsv", emit: qc_counts_metrics
-    path "*_genes.tsv", emit: qc_genes_metrics
 
     script:
-    def mito_prefixes = params.mito_prefixes.join(' ')
     def marker_arg = params.marker_genes ? "\\\n        --marker_genes ${params.marker_genes}" : ""
-    def mito_list_arg = params.mito_gene_list ? "\\\n        --mito_gene_list ${params.mito_gene_list}" : ""
     """
-    run_sam_qc.py \\
-        --sample_id ${meta.id} \\
-        --input_h5ad ${corrected_h5ad} \\
-        --min_genes ${params.min_genes_per_cell} \\
-        --min_cells ${params.min_cells_per_gene} \\
-        --max_genes ${params.max_genes_per_cell} \\
-        --max_counts ${params.max_counts_per_cell} \\
-        --max_mito ${params.max_mito} \\
-        --mito_prefixes ${mito_prefixes} \\
-        --n_hvg ${params.n_hvg} \\
-        --n_neighbors ${params.n_neighbors} \\
-        --n_pcs ${params.n_pcs}  ${marker_arg}${mito_list_arg}
+    run_sam_qc.py \
+        --sample_id ${meta.id} \
+        --input_h5ad ${corrected_h5ad} \
+        --whitelist ${whitelist} \
+        --n_hvg ${params.n_hvg} \
+        --n_neighbors ${params.n_neighbors} \
+        --n_pcs ${params.n_pcs}  ${marker_arg}
     """
 }

--- a/modules/local/scrublet.nf
+++ b/modules/local/scrublet.nf
@@ -1,0 +1,29 @@
+// modules/local/scrublet.nf
+
+process SCRUBLET {
+    tag "$meta.id"
+    publishDir "$params.outdir/scrublet/${meta.id}", mode: 'copy'
+
+    input:
+    tuple val(meta), path(gzipped_dir)
+
+    output:
+    tuple val(meta), path("${meta.id}_whitelist.txt"), emit: whitelist
+    tuple val(meta), path("*.png"), emit: qc_plots
+    path "*_cells.tsv", emit: qc_cells_metrics
+    path "*_counts.tsv", emit: qc_counts_metrics
+    path "*_genes.tsv", emit: qc_genes_metrics
+
+    script:
+    def mito_prefixes = params.mito_prefixes.join(' ')
+    def mito_list_arg = params.mito_gene_list ? "\\\n        --mito_gene_list ${params.mito_gene_list}" : ""
+    """
+    run_scrublet.py \
+        --sample_id ${meta.id} \
+        --matrix_dir ${gzipped_dir}/GeneFull/raw \
+        --min_genes ${params.min_genes_per_cell} \
+        --min_cells ${params.min_cells_per_gene} \
+        --max_mito ${params.max_mito} \
+        --mito_prefixes ${mito_prefixes} ${mito_list_arg}
+    """
+}


### PR DESCRIPTION
## Summary
- run Scrublet on raw STARsolo counts to generate doublet whitelist and QC plots
- filter SoupX output using whitelist in SAM QC
- restructure Nextflow pipeline to execute Scrublet before SoupX and update MultiQC inputs

## Testing
- `python -m py_compile bin/run_scrublet.py bin/run_sam_qc.py`
- `nextflow -version`


------
https://chatgpt.com/codex/tasks/task_e_68a5087217ac8324a168f19d76a6949b