### PR TITLE
Run doublet detection prior to mitochondrial filtering

### DIFF
--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -47,21 +47,21 @@ custom_data:
     file_format: "png"
     plot_type: "image"
 
-  img_violin_mito_qc1:
-    section_name: "sample1 violin before and after mito filtering QC1"
+  img_scatter_doublet_qc1:
+    section_name: "sample1 scatter doublet highlight QC1"
+    description: "Doublet score vs. nCount_RNA; highlighted putative doublets prior to mitochondrial filtering."
+    file_format: "png"
+    plot_type: "image"
+
+  img_violin_comparison_qc1:
+    section_name: "sample1 violin comparison QC1"
+    description: "QC1 distributions after doublet removal; compare to initial state."
+    file_format: "png"
+    plot_type: "image"
+
+  img_violin_mito_qc2:
+    section_name: "sample1 violin before and after mito filtering QC2"
     description: "nCount_RNA / nFeature_RNA distributions before and after mitochondrial filtering."
-    file_format: "png"
-    plot_type: "image"
-
-  img_violin_comparison_qc2:
-    section_name: "sample1 violin comparison QC2"
-    description: "QC2 distributions after filtering; compare to QC1 to assess filtering effects."
-    file_format: "png"
-    plot_type: "image"
-
-  img_scatter_doublet_qc2:
-    section_name: "sample1 scatter doublet highlight QC2"
-    description: "Doublet score vs. nCount_RNA; highlighted putative doublets post-QC2."
     file_format: "png"
     plot_type: "image"
 
@@ -79,21 +79,21 @@ sp:
     fn: "*_marker_genes_heatmap.png"
   img_umap_leiden_qc2:
     fn: "*_umap_leiden_QC2.png"
-  img_violin_mito_qc1:
-    fn: "*_violin_mito_filtering_QC1.png"
-  img_violin_comparison_qc2:
-    fn: "*_violin_comparison_QC2.png"
-  img_scatter_doublet_qc2:
-    fn: "*_scatter_doublet_highlight_QC2.png"
+  img_scatter_doublet_qc1:
+    fn: "*_scatter_doublet_highlight_QC1.png"
+  img_violin_comparison_qc1:
+    fn: "*_violin_comparison_QC1.png"
+  img_violin_mito_qc2:
+    fn: "*_violin_mito_filtering_QC2.png"
 
 custom_content:
   order:
     - cells_metrics
     - counts_metrics
     - genes_metrics
-    - img_violin_mito_qc1
-    - img_violin_comparison_qc2
-    - img_scatter_doublet_qc2
+    - img_scatter_doublet_qc1
+    - img_violin_comparison_qc1
+    - img_violin_mito_qc2
     - img_umap_leiden_qc2
     - img_marker_genes_heatmap
 
@@ -104,8 +104,8 @@ report_section_order:
   "custom_content:cells_metrics": 30
   "custom_content:counts_metrics": 40
   "custom_content:genes_metrics": 50
-  "custom_content:img_violin_mito_qc1": 60
-  "custom_content:img_violin_comparison_qc2": 70
-  "custom_content:img_scatter_doublet_qc2": 80
+  "custom_content:img_scatter_doublet_qc1": 60
+  "custom_content:img_violin_comparison_qc1": 70
+  "custom_content:img_violin_mito_qc2": 80
   "custom_content:img_umap_leiden_qc2": 90
   "custom_content:img_marker_genes_heatmap": 100


### PR DESCRIPTION
## Summary
- Run Scrublet before mitochondrial filtering and configure with expected doublet rate and detailed parameters.
- Generate QC plots and metrics reflecting new doublet-first workflow.
- Update MultiQC config for new QC1/QC2 images.

## Testing
- `python -m py_compile bin/run_scrublet.py`
- `python - <<'PY'
import yaml
yaml.safe_load(open('multiqc_config.yaml'))
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a512183d0c8324bc2954069b53c0a6