### PR TITLE
Wire Scrublet manual threshold into Nextflow params

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ nextflow run ~/BCP_analysis/main.nf -profile standard
   If GeneFull outputs live elsewhere, optionally add a `counts_h5ad` column in `samples.csv` to point to custom `.h5ad`
   locations.
 
+
+### Scrublet threshold override
+
+- By default, Scrublet uses its automatic threshold.
+- To force a manual cutoff, pass `--scrublet_manual_threshold` when launching Nextflow; this value is forwarded to `run_scrublet.py --manual_threshold`.
+
+  ```bash
+  nextflow run ~/BCP_analysis/main.nf --scrublet_manual_threshold 0.25
+  ```
+
 ### Mitochondrial filtering
 
 - **Global threshold** (default): `--max_mito` sets a single mitochondrial percentage cutoff for all samples (default: `0.2`).

--- a/modules/local/scrublet.nf
+++ b/modules/local/scrublet.nf
@@ -16,6 +16,7 @@ process SCRUBLET {
     script:
     def mito_prefixes_str = params.mito_prefixes instanceof List ? params.mito_prefixes.join(' ') : params.mito_prefixes
     def mito_list_arg = params.mito_gene_list ? "\\\n        --mito_gene_list ${params.mito_gene_list}" : ""
+    def manual_threshold_arg = params.scrublet_manual_threshold != null ? "\\\n        --manual_threshold ${params.scrublet_manual_threshold}" : ""
     def mito_max = meta.containsKey('max_mito') ? meta.max_mito : params.max_mito
     def summary_csv = "${gzipped_dir}/GeneFull/Summary.csv"
     def knee_matrix_dir = "${gzipped_dir}/GeneFull/raw"
@@ -28,6 +29,6 @@ process SCRUBLET {
         --min_cells ${params.min_cells_per_gene} \
         --max_mito ${mito_max} \
         --summary_csv ${summary_csv} \
-        --mito_prefixes ${mito_prefixes_str} ${mito_list_arg}
+        --mito_prefixes ${mito_prefixes_str} ${mito_list_arg}${manual_threshold_arg}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,7 @@ params {
     mito_max_map = null
     mito_prefixes = ['mt-']
     mito_gene_list = null
+    scrublet_manual_threshold = null
 
     // Downstream processing
     n_hvg = 3000


### PR DESCRIPTION
### Motivation

- The `run_scrublet.py` script gained a `--manual_threshold` option and the pipeline needs a way to pass a manual cutoff when invoked via Nextflow.

### Description

- Added a new pipeline parameter `scrublet_manual_threshold = null` to `nextflow.config` so users can specify a manual Scrublet cutoff from the Nextflow command line.
- Updated `modules/local/scrublet.nf` to build a conditional `manual_threshold_arg` and append it to the `run_scrublet.py` command only when `params.scrublet_manual_threshold` is provided.
- Documented the new option in `README.md` with an example invocation using `--scrublet_manual_threshold` which is forwarded to `run_scrublet.py --manual_threshold`.

### Testing

- Ran `rg -n "scrublet_manual_threshold|manual_threshold_arg|Scrublet threshold override" nextflow.config modules/local/scrublet.nf README.md` which located the new param, the conditional arg, and the README section (succeeded).
- Attempted `nextflow -v` to validate runtime wiring but the command is not available in this environment so the Nextflow binary check failed with `command not found` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab49513e988324889588ea7a2800fe)